### PR TITLE
Added option to specify commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ In `config/deploy.js`, (which `ember-cli-deploy` will helpfully generate for you
 
  - `branch`: The branch that we will deploy to. It must already exist. Defaults to `"gh-pages"`
  - `repo`: The repo that we will deploy to. It defaults to the value of your containing repo's `origin` remote.
- - `worktreePath`: path where we will create/update a working tree to manipulate the deployment branch. Defaults to `../deploy-${project.name()}`, relative to your project.
+ - `worktreePath`: Path where we will create/update a working tree to manipulate the deployment branch. Defaults to `../deploy-${project.name()}`, relative to your project.
+ - `commitMessage`: Message to use when committing the deployment, where %@ is replaced with the current git revision.
 
 A complete example:
 
@@ -22,7 +23,8 @@ A complete example:
 ENV.git = {
   repo: 'git@github.com:ef4/ember-cli-deploy-git.git',
   branch: 'deploys',
-  worktreePath: '/tmp/ef4-deploy'
+  worktreePath: '/tmp/ef4-deploy',
+  commitMessage: 'Deployed %@'
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ module.exports = {
               myRepo: myRepo,
               repo: pluginConfig.repo || myRepo,
               branch: pluginConfig.branch || 'gh-pages',
-              worktreePath: pluginConfig.worktreePath || defaultWorktree(context)
+              worktreePath: pluginConfig.worktreePath || defaultWorktree(context),
+              commitMessage: pluginConfig.commitMessage || 'Deployed %@'
             }
           };
         }).catch(showStderr(context.ui));
@@ -28,9 +29,9 @@ module.exports = {
         var d = context.gitDeploy;
         var distDir = context.distDir || path.join(context.project.root, 'dist');
         return git.prepareTree(d.worktreePath, d.myRepo, d.repo, d.branch)
-          .then(function(){
-            return git.replaceTree(d.worktreePath, distDir);
-          }).then(function(didCommit){
+          .then(function() {
+            return git.replaceTree(d.worktreePath, distDir, d.commitMessage);
+          }).then(function(didCommit) {
             if (didCommit) {
               return git.push(d.worktreePath, d.repo, d.branch);
             } else {

--- a/lib/git.js
+++ b/lib/git.js
@@ -14,6 +14,12 @@ function supportsWorktree() {
   });
 }
 
+function currentRevision() {
+  return run('git', ['rev-parse', '--short', 'HEAD']).then(function(output) {
+    return output.stdout;
+  });
+}
+
 function prepareTree(targetDir, myRepo, repo, branch) {
   return stat(targetDir).then(function() {
     return run('git', ['reset', '--hard'], {cwd: targetDir}).then(function(){
@@ -33,13 +39,17 @@ function prepareTree(targetDir, myRepo, repo, branch) {
   });
 }
 
-function replaceTree(targetDir, ourDir) {
+function replaceTree(targetDir, ourDir, commitMessage) {
   return run("git", ["rm", "--ignore-unmatch", "-r", "."], {cwd: targetDir}).then(function(){
     return copy(ourDir, targetDir, {stopOnErr:true});
-  }).then(function(){
+  }).then(function() {
     return run('git', ['add', '-A'], {cwd: targetDir});
-  }).then(function(){
-    return run('git', ['commit', '-m', 'deploy'], {cwd: targetDir}).catch(function(err){
+  }).then(function() {
+    return currentRevision();
+  }).then(function(revision) {
+    commitMessage = commitMessage.replace(/%@/g, revision);
+
+    return run('git', ['commit', '-m', commitMessage], {cwd: targetDir}).catch(function(err){
       if (/nothing to commit/.test(err.stdout)) {
         return false;
       }


### PR DESCRIPTION
Hey! I noticed that commit message created now always is _'deploy'_, so I added the ability to specify a custom one ([similiar to ember-cli-release](https://github.com/lytics/ember-cli-release#options)). Let me know what you think.