### PR TITLE
Use RSVP instead of ember-cli/ext/promise

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -1,10 +1,10 @@
 /* jshint node: true */
 
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP  = require('rsvp');
 var spawn = require('child_process').spawn;
 
 function run(command, args, opts) {
-  return new Promise(function(resolve, reject) {
+  return new RSVP.Promise(function(resolve, reject) {
     var p = spawn(command, args, opts || {});
     var stderr = '';
     var stdout = '';


### PR DESCRIPTION
Fixes the following deprecation warning:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead. Required here: 
  Object.<anonymous> (/node_modules/ember-cli-deploy-git/lib/run.js:3:17)
```