### PR TITLE
Let npm install addons deps 😎

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you have a recent version of git that supports `git worktree`, and you're dep
 
 ## Installation
 
-`ember install ember-cli-deploy ember-cli-deploy-build ember-cli-deploy-git`
+`ember install ember-cli-deploy-git`
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-deploy": "^1.0.1",
+    "ember-cli-deploy-build": "^1.1.0",
     "ember-cli-deploy-plugin": "^0.2.0",
     "ncp": "^2.0.0",
     "rsvp": "^3.1.0"


### PR DESCRIPTION
Instead of having the user `ember install` addons this addon is dependent on, we can just add these to our package.json dependencies, and we'll be good.

As described here: https://ember-cli.com/extending/#addons-depending-on-other-addons.