### PR TITLE
Allow for deploying to a particular directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ In `config/deploy.js`, (which `ember-cli-deploy` will helpfully generate for you
  - `branch`: The branch that we will deploy to. It must already exist. Defaults to `"gh-pages"`
  - `repo`: The repo that we will deploy to. It defaults to the value of your containing repo's `origin` remote.
  - `worktreePath`: Path where we will create/update a working tree to manipulate the deployment branch. Defaults to `../deploy-${project.name()}`, relative to your project.
+ - `destDir`: A directory within the given branch that we will deploy to. Defaults to the root of the repo.
  - `commitMessage`: Message to use when committing the deployment, where %@ is replaced with the current git revision.
 
 A complete example:

--- a/index.js
+++ b/index.js
@@ -14,12 +14,14 @@ module.exports = {
       configure: function(context) {
         var pluginConfig = context.config[this.name] || {};
         return getMyRepo(context).then(function(myRepo) {
+          var worktreePath = pluginConfig.worktreePath || defaultWorktree(context);
           return {
             gitDeploy: {
               myRepo: myRepo,
+              worktreePath: worktreePath,
+              destDir: path.resolve(worktreePath, pluginConfig.destDir || ''),
               repo: pluginConfig.repo || myRepo,
               branch: pluginConfig.branch || 'gh-pages',
-              worktreePath: pluginConfig.worktreePath || defaultWorktree(context),
               commitMessage: pluginConfig.commitMessage || 'Deployed %@'
             }
           };
@@ -30,7 +32,7 @@ module.exports = {
         var distDir = context.distDir || path.join(context.project.root, 'dist');
         return git.prepareTree(d.worktreePath, d.myRepo, d.repo, d.branch)
           .then(function() {
-            return git.replaceTree(d.worktreePath, distDir, d.commitMessage);
+            return git.replaceTree(d.destDir, distDir, d.commitMessage);
           }).then(function(didCommit) {
             if (didCommit) {
               return git.push(d.worktreePath, d.repo, d.branch);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,6 +1,6 @@
 /* jshint node: true */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var RSVP = require('rsvp');
 var run = require('./run');
 var stat = RSVP.denodeify(fs.stat);
@@ -40,7 +40,9 @@ function prepareTree(targetDir, myRepo, repo, branch) {
 }
 
 function replaceTree(targetDir, ourDir, commitMessage) {
-  return run("git", ["rm", "--ignore-unmatch", "-r", "."], {cwd: targetDir}).then(function(){
+  return fs.ensureDir(targetDir).then(function() {
+    return run("git", ["rm", "--ignore-unmatch", "-r", "."], {cwd: targetDir});
+  }).then(function(){
     return copy(ourDir, targetDir, {stopOnErr:true});
   }).then(function() {
     return run('git', ['add', '-A'], {cwd: targetDir});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "fs-extra": "^4.0.0",
     "ncp": "^2.0.0",
     "rsvp": "^3.1.0"
   },


### PR DESCRIPTION
For managing versioned guides in [ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs), we're looking at having multiple copies of an app deployed at different locations on a single `gh-pages` branch. To support that, we'd need to be able to deploy into specific subdirectories rather than just the root.

I went with `destDir` since it's a familiar name for the concept from other libs like `broccoli-funnel`, but if there's other terminology you'd prefer, I don't feel strongly.