### PR TITLE
Check out branch sooner, document `worktreePath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ if (environment === 'production') {
 
 ** If you're using Ember-CLI 2.6 or older, [you will need to use `baseURL` instead of `rootURL`](https://emberjs.com/blog/2016/04/28/baseURL.html).**
 
+### Coordination With Other Plugins
+
+This plugin checks out the target branch during the `prepare` phase of the deploy, and writes the new build output there during the `upload` phase. Between those two phases, the location of this checkout is available at `context.gitDeploy.worktreePath` for other plugins that wish to pull information from the previous deployed commit.
+
 ### How to Deploy
 
 `ember deploy production`

--- a/index.js
+++ b/index.js
@@ -27,13 +27,15 @@ module.exports = {
           };
         }).catch(showStderr(context.ui));
       },
+      prepare: function(context) {
+        var d = context.gitDeploy;
+        return git.prepareTree(d.worktreePath, d.myRepo, d.repo, d.branch);
+      },
       upload: function(context) {
         var d = context.gitDeploy;
         var distDir = context.distDir || path.join(context.project.root, 'dist');
-        return git.prepareTree(d.worktreePath, d.myRepo, d.repo, d.branch)
-          .then(function() {
-            return git.replaceTree(d.destDir, distDir, d.commitMessage);
-          }).then(function(didCommit) {
+        return git.replaceTree(d.destDir, distDir, d.commitMessage)
+          .then(function(didCommit) {
             if (didCommit) {
               return git.push(d.worktreePath, d.repo, d.branch);
             } else {


### PR DESCRIPTION
Per #15, this change moves the worktree preparation into the `prepare` phase of the deploy and documents that behavior, as well as the presence of `gitDeploy.worktreePath` on the deploy context.