### PR TITLE
Update ember-cli-babel to remove deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "github pages"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^6.11.0",
     "ember-cli-deploy-plugin": "^0.2.0",
     "fs-extra": "^4.0.0",
     "ncp": "^2.0.0",


### PR DESCRIPTION
The addon ember-cli-babel depends on ember-cli-version-checker@1.3.1, which throws a deprecation warning (see https://github.com/ember-cli/ember-cli-version-checker/issues/48). ember-cli-babel 6.x uses the newer ember-cli-version-checker. Stepping up a major babel version (from 5.x to 6.x) should not cause issues.

Cheers ✌🏻