### PR TITLE
Use fs-extra instead of ncp to avoid race condition

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,10 +1,9 @@
 /* jshint node: true */
 
 var fs = require('fs-extra');
-var RSVP = require('rsvp');
 var run = require('./run');
-var stat = RSVP.denodeify(fs.stat);
-var copy = RSVP.denodeify(require('ncp').ncp);
+var stat = fs.stat;
+var copy = fs.copy;
 
 function supportsWorktree() {
   return run('git', ['help', 'worktree']).then(function() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-babel": "^6.11.0",
     "ember-cli-deploy-plugin": "^0.2.9",
     "fs-extra": "^5.0.0",
-    "ncp": "^2.0.0",
     "rsvp": "^4.8.1"
   },
   "ember-addon": {


### PR DESCRIPTION
I've been hitting an issue where large files were being committed to my deploy branch before they were completely copied, and after hunting around for a forgotten promise return in my own code, eventually found my way to [this ncp issue](https://github.com/AvianFlu/ncp/issues/127). It looks like there hasn't been much activity on that project for a while, and there are a number of similar issues sitting open.

Since we're already using `fs-extra` here, I dropped `ncp` in favor of just using the `copy` implementation there (which I believe was originally based on `ncp`, but has continued to be maintained).