### PR TITLE
Add verbose log message pointing to git prepare directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
       },
       prepare: function(context) {
         var d = context.gitDeploy;
+        this.log("preparing git in " + d.worktreePath, { verbose: true });
         return git.prepareTree(d.worktreePath, d.myRepo, d.repo, d.branch);
       },
       upload: function(context) {


### PR DESCRIPTION
Adds a log message showing the location of the directory where the actual git prepare is running (but only if `--verbose` is passed).

Might be useful for other users encountering git errors and not being able to reproduce/fix because they are not aware of the "sibling directory" being used. Like was the case here https://github.com/ef4/ember-cli-deploy-git/issues/20.