### PR TITLE
fix: `pull --rebase` before `push`

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -81,7 +81,10 @@ function replaceTree(targetDir, ourDir, commitMessage) {
 }
 
 function push(targetDir, repo, branch) {
-  return run("git", ["push", repo, branch], { cwd: targetDir });
+  return run("git", ["pull", "--rebase", repo, branch], { cwd: targetDir })
+    .then(function () {
+      return run("git", ["push", repo, branch], { cwd: targetDir });
+    });
 }
 
 function origin(targetDir) {


### PR DESCRIPTION
When commits are pushed to CI in quick succession, the deployment can fail with this error:

```
+- upload
|  |
|  +- git
To ember-intl/ember-intl.git
 ! [rejected]          gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'ember-intl/ember-intl.git'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
|
+- didFail
Error: git push ember-intl/ember-intl.git gh-pages exited with nonzero status
Error: git push ember-intl/ember-intl.git gh-pages exited with nonzero status
    at ChildProcess.<anonymous> (/home/runner/work/ember-intl/ember-intl/node_modules/ember-cli-deploy-git/lib/run.js:17:19)
    at ChildProcess.emit (events.js:315:20)
    at ChildProcess.EventEmitter.emit (domain.js:486:12)
    at maybeClose (internal/child_process.js:1048:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:288:5)
|
Pipeline aborted
``` 

https://github.com/ember-intl/ember-intl/runs/1571595497

The reason is that the prior CI run is pushing a new commit, while the current CI run is building. Once the current CI run then tries to push, the remote rejects, as the new commit from the prior run is missing.

By running `git pull --rebase` before `git push`, we can avoid this.

(Disclaimer: I haven't tested this yet, but can give it a shot later.)